### PR TITLE
refactor: move data into DTO in preparation for html rendering

### DIFF
--- a/src/main/java/net/nitrado/hytale/plugins/query/QueryResponseV1.java
+++ b/src/main/java/net/nitrado/hytale/plugins/query/QueryResponseV1.java
@@ -1,0 +1,239 @@
+package net.nitrado.hytale.plugins.query;
+
+import com.hypixel.hytale.common.plugin.PluginIdentifier;
+import com.hypixel.hytale.common.util.java.ManifestUtil;
+import com.hypixel.hytale.protocol.ProtocolSettings;
+import com.hypixel.hytale.server.core.HytaleServer;
+import com.hypixel.hytale.server.core.plugin.PluginBase;
+import com.hypixel.hytale.server.core.plugin.PluginManager;
+import com.hypixel.hytale.server.core.universe.Universe;
+import org.bson.Document;
+
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class QueryResponseV1 {
+
+    private BasicData basic;
+    private ServerData server;
+    private UniverseData universe;
+    private List<PlayerData> players;
+    private List<PluginData> plugins;
+    private InetSocketAddress address;
+
+    public QueryResponseV1(InetSocketAddress publicAddress) {
+        this.address = publicAddress;
+    }
+
+    public BasicData getBasic() {
+        return basic;
+    }
+
+    public ServerData getServer() {
+        return server;
+    }
+
+    public UniverseData getUniverse() {
+        return universe;
+    }
+
+    public List<PlayerData> getPlayers() {
+        return players;
+    }
+
+    public List<PluginData> getPlugins() {
+        return plugins;
+    }
+
+    public void addBasicData() {
+        this.basic = new BasicData(
+                HytaleServer.get().getServerName(),
+                ManifestUtil.getImplementationVersion(),
+                HytaleServer.get().getConfig().getMaxPlayers(),
+                Universe.get().getPlayerCount(),
+                address
+        );
+    }
+
+    public void addServerData() {
+        this.server = new ServerData(
+                HytaleServer.get().getServerName(),
+                ManifestUtil.getImplementationVersion(),
+                ManifestUtil.getImplementationRevisionId(),
+                ManifestUtil.getPatchline(),
+                ProtocolSettings.PROTOCOL_VERSION,
+                ProtocolSettings.PROTOCOL_HASH,
+                HytaleServer.get().getConfig().getMaxPlayers(),
+                address
+        );
+    }
+
+    public void addUniverseData() {
+        var defaultWorld = Universe.get().getDefaultWorld();
+        this.universe = new UniverseData(
+                Universe.get().getPlayerCount(),
+                defaultWorld == null ? null : defaultWorld.getName()
+        );
+    }
+
+    public void addPlayerData() {
+        this.players = new ArrayList<>();
+        for (var entry : Universe.get().getWorlds().entrySet()) {
+            var world = entry.getValue();
+            for (var ref : world.getPlayerRefs()) {
+                players.add(new PlayerData(
+                        ref.getUsername(),
+                        ref.getUuid().toString(),
+                        world.getName()
+                ));
+            }
+        }
+    }
+
+    public void addPluginData() {
+        this.plugins = new ArrayList<>();
+        var pluginsList = PluginManager.get().getPlugins();
+        var pluginMap = new HashMap<PluginIdentifier, PluginBase>(pluginsList.size());
+
+        for (var plugin : pluginsList) {
+            pluginMap.put(plugin.getIdentifier(), plugin);
+        }
+
+        for (var manifest : PluginManager.get().getAvailablePlugins().values()) {
+            var pluginIdentifier = new PluginIdentifier(manifest);
+            var plugin = pluginMap.get(pluginIdentifier);
+            this.plugins.add(new PluginData(
+                    pluginIdentifier.toString(),
+                    manifest.getVersion().toString(),
+                    plugin != null,
+                    plugin != null ? plugin.isEnabled() : null,
+                    plugin != null ? plugin.getState().toString() : null
+            ));
+        }
+    }
+
+    public Document toDocument() {
+        Document doc = new Document();
+
+        if (basic != null) {
+            var basicDoc = new Document();
+            basicDoc.append("Name", basic.name())
+                    .append("Version", basic.version())
+                    .append("MaxPlayers", basic.maxPlayers())
+                    .append("CurrentPlayers", basic.currentPlayers());
+
+            if (basic.address() != null) {
+                basicDoc.append("Address", formatAddress(basic.address()));
+            }
+
+            doc.append("Basic", basicDoc);
+        }
+
+        if (server != null) {
+            var serverDoc = new Document();
+            serverDoc
+                    .append("Name", server.name())
+                    .append("Version", server.version())
+                    .append("Revision", server.revision())
+                    .append("Patchline", server.patchline())
+                    .append("ProtocolVersion", server.protocolVersion())
+                    .append("ProtocolHash", server.protocolHash())
+                    .append("MaxPlayers", server.maxPlayers());
+
+            if (server.address() != null) {
+                serverDoc.append("Address", formatAddress(server.address()));
+            }
+
+            doc.append("Server", serverDoc);
+        }
+
+        if (universe != null) {
+            doc.append("Universe", new Document()
+                    .append("CurrentPlayers", universe.currentPlayers())
+                    .append("DefaultWorld", universe.defaultWorld())
+            );
+        }
+
+        if (players != null) {
+            var playerDocs = new ArrayList<Document>();
+            for (var player : players) {
+                playerDocs.add(new Document()
+                        .append("Name", player.name())
+                        .append("UUID", player.uuid())
+                        .append("World", player.world())
+                );
+            }
+            doc.append("Players", playerDocs);
+        }
+
+        if (plugins != null) {
+            var pluginDoc = new Document();
+            for (var plugin : plugins) {
+                var entry = new Document()
+                        .append("Version", plugin.version())
+                        .append("Loaded", plugin.loaded());
+                if (plugin.loaded()) {
+                    entry.append("Enabled", plugin.enabled())
+                          .append("State", plugin.state());
+                }
+                pluginDoc.append(plugin.identifier(), entry);
+            }
+            doc.append("Plugins", pluginDoc);
+        }
+
+        return doc;
+    }
+
+    public record BasicData(
+            String name,
+            String version,
+            int maxPlayers,
+            int currentPlayers,
+            InetSocketAddress address
+    ) {}
+
+    public record ServerData(
+            String name,
+            String version,
+            String revision,
+            String patchline,
+            int protocolVersion,
+            String protocolHash,
+            int maxPlayers,
+            InetSocketAddress address
+    ) {}
+
+    public record UniverseData(
+            int currentPlayers,
+            String defaultWorld
+    ) {}
+
+    public record PlayerData(
+            String name,
+            String uuid,
+            String world
+    ) {}
+
+    public record PluginData(
+            String identifier,
+            String version,
+            boolean loaded,
+            Boolean enabled,
+            String state
+    ) {}
+
+    private String formatAddress(InetSocketAddress address) {
+            String formatted;
+
+            formatted = address.getHostString();
+            if (formatted.contains(":")) {
+                // IPv6
+                formatted = "[" + formatted + "]";
+            }
+
+            return formatted + ":" + address.getPort();
+    }
+}

--- a/src/main/java/net/nitrado/hytale/plugins/query/QueryServlet.java
+++ b/src/main/java/net/nitrado/hytale/plugins/query/QueryServlet.java
@@ -1,31 +1,18 @@
 package net.nitrado.hytale.plugins.query;
 
-import com.hypixel.hytale.common.plugin.PluginIdentifier;
-import com.hypixel.hytale.common.plugin.PluginManifest;
-import com.hypixel.hytale.common.util.java.ManifestUtil;
-import com.hypixel.hytale.protocol.ProtocolSettings;
-import com.hypixel.hytale.server.core.HytaleServer;
-import com.hypixel.hytale.server.core.plugin.PluginBase;
-import com.hypixel.hytale.server.core.plugin.PluginManager;
-import com.hypixel.hytale.server.core.universe.Universe;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import net.nitrado.hytale.plugins.webserver.authentication.HytaleUserPrincipal;
 import net.nitrado.hytale.plugins.webserver.authorization.RequirePermissions;
 import net.nitrado.hytale.plugins.webserver.util.RequestUtils;
-import org.bson.Document;
 import org.bson.json.JsonWriterSettings;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.WebContext;
 import org.thymeleaf.web.servlet.JakartaServletWebApplication;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
 
 public class QueryServlet extends HttpServlet {
 
@@ -95,32 +82,37 @@ public class QueryServlet extends HttpServlet {
     protected void handleJsonV1(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         resp.setContentType(JSON_V1);
 
-        Document doc = new Document();
+        var response = buildQueryResponse(req);
+        resp.getWriter().println(response.toDocument().toJson(JsonWriterSettings.builder().indent(true).build()));
+    }
+
+    protected QueryResponseV1 buildQueryResponse(HttpServletRequest req) {
+        var response = new QueryResponseV1(publicAddress);
 
         var principal = req.getUserPrincipal();
         if (principal instanceof HytaleUserPrincipal user) {
             if (user.hasPermission(Permissions.WEB_READ_BASIC)) {
-                this.addBasicData(doc);
+                response.addBasicData();
             }
 
             if (user.hasPermission(Permissions.WEB_READ_SERVER)) {
-                this.addServerData(doc);
+                response.addServerData();
             }
 
             if (user.hasPermission(Permissions.WEB_READ_PLAYERS)) {
-                this.addPlayerData(doc);
+                response.addPlayerData();
             }
 
             if (user.hasPermission(Permissions.WEB_READ_UNIVERSE)) {
-                this.addUniverseData(doc);
+                response.addUniverseData();
             }
 
             if (user.hasPermission(Permissions.WEB_READ_PLUGINS)) {
-                this.addPluginData(doc);
+                response.addPluginData();
             }
         }
 
-        resp.getWriter().println(doc.toJson(JsonWriterSettings.builder().indent(true).build()));
+        return response;
     }
 
     /**
@@ -129,105 +121,5 @@ public class QueryServlet extends HttpServlet {
      */
     private void setDeprecationHeader(HttpServletResponse resp) {
         resp.setHeader("Deprecation", "true");
-    }
-
-    protected void addBasicData(Document doc) {
-        var basicDoc = new Document()
-                .append("Name", HytaleServer.get().getServerName())
-                .append("Version", ManifestUtil.getImplementationVersion())
-                .append("MaxPlayers", HytaleServer.get().getConfig().getMaxPlayers())
-                .append("CurrentPlayers", Universe.get().getPlayerCount());
-
-        if (this.publicAddress != null) {
-            basicDoc.append("Address", this.publicAddress.toString());
-        }
-
-        doc.append("Basic", basicDoc);
-    }
-
-    protected void addServerData(Document doc) {
-        var serverDoc = new Document()
-                .append("Name", HytaleServer.get().getServerName())
-                .append("Version", ManifestUtil.getImplementationVersion())
-                .append("Revision", ManifestUtil.getImplementationRevisionId())
-                .append("Patchline", ManifestUtil.getPatchline())
-                .append("ProtocolVersion", ProtocolSettings.PROTOCOL_VERSION)
-                .append("ProtocolHash", ProtocolSettings.PROTOCOL_HASH)
-                .append("MaxPlayers", HytaleServer.get().getConfig().getMaxPlayers());
-
-        if (this.publicAddress != null) {
-            serverDoc.append("Address", this.publicAddress.toString());
-        }
-
-        doc.append("Server", serverDoc);
-    }
-
-    protected void addUniverseData(Document doc) {
-        var defaultWorld = Universe.get().getDefaultWorld();
-        var universeDoc = new Document()
-                .append("CurrentPlayers", Universe.get().getPlayerCount())
-                .append("DefaultWorld", defaultWorld == null ? null : defaultWorld.getName());
-
-        var universeWorlds = Universe.get().getWorlds();
-
-        var worlds = new ArrayList<Document>();
-        universeWorlds.forEach((name, world) -> {
-            worlds.add(new Document()
-                    .append("Name", name)
-                    .append("CurrentPlayers", world.getPlayerCount())
-                    .append("IsDeleteOnRemove", world.getWorldConfig().isDeleteOnRemove())
-            );
-        });
-        universeDoc.append("Worlds", worlds);
-
-        doc.append("Universe", universeDoc);
-    }
-
-    protected void addPlayerData(Document doc) {
-        var players = new ArrayList<Document>();
-        for (var entry : Universe.get().getWorlds().entrySet()) {
-            var world = entry.getValue();
-            for (var ref : world.getPlayerRefs()) {
-
-                players.add(new Document()
-                        .append("Name", ref.getUsername())
-                        .append("UUID", ref.getUuid().toString())
-                        .append("World", world.getName())
-                );
-            }
-        }
-
-        doc.append("Players", players);
-    }
-
-    protected void addPluginData(Document doc) {
-        var pluginDoc =  new Document();
-        var plugins = PluginManager.get().getPlugins();
-        var pluginMap = new HashMap<PluginIdentifier, PluginBase>(plugins.size());
-
-        for (var plugin : plugins) {
-            pluginMap.put(plugin.getIdentifier(), plugin);
-        }
-
-        for (var manifest : PluginManager.get().getAvailablePlugins().values()) {
-            var pluginIdentifier = new PluginIdentifier(manifest);
-            pluginDoc.append(pluginIdentifier.toString(),
-                    pluginToDoc(manifest, pluginMap.get(pluginIdentifier)));
-        }
-
-        doc.append("Plugins", pluginDoc);
-    }
-
-    protected Document pluginToDoc(@Nonnull PluginManifest manifest, @Nullable PluginBase plugin) {
-        var result = new Document();
-
-        result.append("Version", manifest.getVersion().toString());
-        result.append("Loaded", plugin != null);
-        if (plugin != null) {
-            result.append("Enabled", plugin.isEnabled());
-            result.append("State", plugin.getState().toString());
-        }
-
-        return result;
     }
 }


### PR DESCRIPTION
This refactoring moves the query response data into a separate data transfer object which will be used in HTML templates in an upcoming change.

Also fixes previously broken rendering of the public address in json responses