### PR TITLE
Fix: Add ServerVersion to manifest.json

### DIFF
--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -2,6 +2,7 @@
   "Group": "Nitrado",
   "Name": "Query",
   "Version": "1.0.0",
+  "ServerVersion": "2026.02.17-255364b8e",
   "Authors": [
     {
       "Name": "André Becker",


### PR DESCRIPTION
In the latest version of Hytale, a mod must include the game server version to be recognized as up to date. I added this line, and it resolved the issue.