### PR TITLE
build: automatic build on new Hytale server version

### DIFF
--- a/.github/workflows/check-for-new-server-version.yml
+++ b/.github/workflows/check-for-new-server-version.yml
@@ -1,0 +1,12 @@
+name: Check for new Hytale Server version
+
+on:
+  schedule:
+    - cron: '0 */1 * * *'  # every 6 hours
+  workflow_dispatch:         # allow manual triggers
+
+jobs:
+  check:
+    uses: nitrado/hytale-plugin-workflows/.github/workflows/rebuild-on-new-server-version.yml@v2
+    with:
+      artifact-id: nitrado-query


### PR DESCRIPTION
This uses v2 of the shared workflow (https://github.com/nitrado/hytale-plugin-workflows/tree/v2) to automatically build new plugin versions when the server version changes